### PR TITLE
ARGO-1004 UTC timestamp instead of localtime for dispatched results

### DIFF
--- a/argo-nagios-ams-publisher.spec
+++ b/argo-nagios-ams-publisher.spec
@@ -22,12 +22,13 @@ Source0:        %{name}-%{version}.tar.gz
 BuildRoot:      %{_tmppath}/%{name}-%{version}-%{release}-root-%(%{__id_u} -n)
 BuildArch:      noarch 
 BuildRequires:  python-devel
-Requires:       python-daemon
-Requires:       python-argparse
-Requires:       python-messaging
-Requires:       python-dirq
-Requires:       avro
 Requires:       argo-ams-library
+Requires:       avro
+Requires:       python-argparse
+Requires:       python-daemon
+Requires:       python-dirq
+Requires:       python-messaging
+Requires:       pytz
 
 %if 0%{?el7:1}
 Requires:       python2-psutil >= 4.3

--- a/config/ams-publisher.conf
+++ b/config/ams-publisher.conf
@@ -8,6 +8,7 @@ PublishArgoMessaging = True
 PublishRetry = 3
 PublishTimeout = 60
 MsgAvroSchema = /etc/argo-nagios-ams-publisher/metric_data.avsc
+TimeZone = UTC
 
 [Connection]
 Retry = 5

--- a/helpers/ams-msg-generator.py
+++ b/helpers/ams-msg-generator.py
@@ -3,20 +3,22 @@
 import argparse
 import datetime
 import messaging.generator as generator
-import random
-import sys
 import os
 import pwd
+import random
+import sys
 import time
 
 from messaging.message import Message
 from messaging.error import MessageError
 from messaging.queue.dqs import DQS
 
+from pytz import timezone, UnknownTimeZoneError
+
 default_queue = '/var/spool/argo-nagios-ams-publisher/outgoing-messages/'
 default_user = 'nagios'
 
-def construct_msg(session=None, bodysize=40):
+def construct_msg(session, bodysize, timezone):
     statusl = ['OK', 'WARNING', 'MISSING', 'CRITICAL', 'UNKNOWN', 'DOWNTIME']
 
     try:
@@ -30,7 +32,7 @@ def construct_msg(session=None, bodysize=40):
         msg.header.update({'hostname': generator.rndb64(10)})
         msg.header.update({'metric': generator.rndb64(10)})
         msg.header.update({'monitoring_host': generator.rndb64(10)})
-        msg.header.update({'timestamp': str(datetime.datetime.now().strftime('%Y-%m-%dT%H:%M:%SZ'))})
+        msg.header.update({'timestamp': str(datetime.datetime.now(timezone).strftime('%Y-%m-%dT%H:%M:%SZ'))})
         msg.header.update({'status': random.choice(statusl)})
 
         msg.body += 'summary: %s\n' % generator.rndb64(20)
@@ -67,22 +69,28 @@ def main():
     parser.add_argument('--noout', required=False, action='store_true', default=False)
     parser.add_argument('--sleep', required=False, default=0, type=float)
     parser.add_argument('--bodysize', required=False, default=40, type=int)
+    parser.add_argument('--timezone', required=False, default='Europe/Zagreb', type=str)
     args = parser.parse_args()
 
     seteuser(pwd.getpwnam(args.runas))
+    try:
+        tz = timezone(args.timezone)
+    except UnknownTimeZoneError as e:
+        print "Timezone not correct"
+        raise SystemExit(1)
 
     mq = DQS(path=args.queue, granularity=args.granularity)
 
     try:
         if args.num:
             for i in range(args.num):
-                msg = construct_msg(args.session, args.bodysize)
+                msg = construct_msg(args.session, args.bodysize, tz)
                 queue_msg(msg, mq)
                 if not args.noout:
                     print msg
         else:
             while True:
-                msg = construct_msg(args.session, args.bodysize)
+                msg = construct_msg(args.session, args.bodysize, tz)
                 queue_msg(msg, mq)
                 if not args.noout:
                     print msg

--- a/helpers/ams-msg-generator.py
+++ b/helpers/ams-msg-generator.py
@@ -69,7 +69,7 @@ def main():
     parser.add_argument('--noout', required=False, action='store_true', default=False)
     parser.add_argument('--sleep', required=False, default=0, type=float)
     parser.add_argument('--bodysize', required=False, default=40, type=int)
-    parser.add_argument('--timezone', required=False, default='Europe/Zagreb', type=str)
+    parser.add_argument('--timezone', required=False, default='UTC', type=str)
     args = parser.parse_args()
 
     seteuser(pwd.getpwnam(args.runas))

--- a/init/ams-publisher
+++ b/init/ams-publisher
@@ -11,35 +11,31 @@ NN="$(which tr) '\n' '\0'"
 
 case "$1" in
 start)
-	echo -n $"Starting $PROG_NAME: "
+	echo $"Starting $PROG_NAME: "
 	msg=$(daemon $DAEMON_PATH -d start)
 	retval=$?
-	echo $msg | eval $NN
-	echo
+	echo $msg
 	exit $retval
 ;;
 stop)
-	echo -n $"Stopping $PROG_NAME: "
+	echo $"Stopping $PROG_NAME: "
 	msg=$(daemon $DAEMON_PATH -d stop)
 	retval=$?
-	echo $msg | eval $NN
-	echo
+	echo $msg
 	exit $retval
 ;;
 restart)
-	echo -n $"Restarting $PROG_NAME: "
+	echo $"Restarting $PROG_NAME: "
 	msg=$(daemon $DAEMON_PATH -d restart)
 	retval=$?
-	echo $msg | eval $NN
-	echo
+	echo $msg
 	exit $retval
 ;;
 status)
-	echo -n $"Status $PROG_NAME: "
+	echo $"Status $PROG_NAME: "
 	msg=$(daemon $DAEMON_PATH -d status)
 	retval=$?
-	echo $msg | eval $NN
-	echo
+	echo $msg
 	exit $retval
 ;;
 *)

--- a/init/ams-publisher
+++ b/init/ams-publisher
@@ -7,7 +7,6 @@
 . /etc/rc.d/init.d/functions
 PROG_NAME="ams-publisherd"
 DAEMON_PATH="/usr/bin/ams-publisherd"
-NN="$(which tr) '\n' '\0'"
 
 case "$1" in
 start)

--- a/pymod/alarmtoqueue.py
+++ b/pymod/alarmtoqueue.py
@@ -8,10 +8,11 @@ from argo_nagios_ams_publisher import config
 from argo_nagios_ams_publisher import log
 
 import argparse
+import datetime
 import os
 import pwd
+import pytz
 import sys
-import datetime
 
 conf = '/etc/argo-nagios-ams-publisher/ams-publisher.conf'
 logfile = '/var/log/argo-nagios-ams-publisher/ams-publisher.log'
@@ -46,7 +47,8 @@ def main():
     logger = lobj.get()
     confopts = config.parse_config(logger)
     nagioshost = confopts['general']['host']
-    timestamp = datetime.datetime.now().strftime('%Y-%m-%dT%H:%M:%SZ')
+    tz = pytz.timezone(confopts['general']['timezone'])
+    timestamp = datetime.datetime.now(tz).strftime('%Y-%m-%dT%H:%M:%SZ')
 
     parser.add_argument('--queue', required=True, type=str)
 

--- a/pymod/config.py
+++ b/pymod/config.py
@@ -1,4 +1,5 @@
 import ConfigParser
+import sys
 
 conf = '/etc/argo-nagios-ams-publisher/ams-publisher.conf'
 
@@ -43,6 +44,7 @@ def parse_config(logger=None):
                     confopts['general'].update({'publishmsgfiledir': config.get(section, 'PublishMsgFileDir')})
                     confopts['general'].update({'publishargomessaging': eval(config.get(section, 'PublishArgoMessaging'))})
                     confopts['general'].update({'msgavroschema': config.get(section, 'MsgAvroSchema')})
+                    confopts['general'].update({'timezone': config.get(section, 'TimeZone')})
                 if section.startswith('Connection'):
                     confopts['connection'] = ({'retry': int(config.get(section, 'Retry'))})
                     confopts['connection'].update({'timeout': int(config.get(section, 'Timeout'))})
@@ -109,8 +111,12 @@ def parse_config(logger=None):
             raise SystemExit(1)
 
     except (ConfigParser.NoOptionError, ConfigParser.NoSectionError) as e:
-        logger.error(e)
-        raise SystemExit(1)
+        if logger:
+            logger.error(e)
+            raise SystemExit(1)
+        else:
+            sys.stderr.write(str(e) + '\n')
+            raise SystemExit(1)
 
     except (ConfigParser.MissingSectionHeaderError, ConfigParser.ParsingError, SystemExit) as e:
         if getattr(e, 'filename', False):

--- a/pymod/config.py
+++ b/pymod/config.py
@@ -1,5 +1,6 @@
 import ConfigParser
 import sys
+from pytz import timezone, UnknownTimeZoneError
 
 conf = '/etc/argo-nagios-ams-publisher/ams-publisher.conf'
 
@@ -45,6 +46,15 @@ def parse_config(logger=None):
                     confopts['general'].update({'publishargomessaging': eval(config.get(section, 'PublishArgoMessaging'))})
                     confopts['general'].update({'msgavroschema': config.get(section, 'MsgAvroSchema')})
                     confopts['general'].update({'timezone': config.get(section, 'TimeZone')})
+                    try:
+                        tz = timezone(confopts['general']['timezone'])
+                    except UnknownTimeZoneError as e:
+                        if logger:
+                            logger.error('Unknown timezone defined: {0}\n'.format(str(e)))
+                            raise SystemExit(1)
+                        else:
+                            sys.stderr.write('Unknown timezone defined: {0}\n'.format(str(e)))
+                            raise SystemExit(1)
                 if section.startswith('Connection'):
                     confopts['connection'] = ({'retry': int(config.get(section, 'Retry'))})
                     confopts['connection'].update({'timeout': int(config.get(section, 'Timeout'))})

--- a/pymod/metrictoqueue.py
+++ b/pymod/metrictoqueue.py
@@ -12,6 +12,7 @@ import os
 import pwd
 import sys
 import datetime
+import pytz
 
 conf = '/etc/argo-nagios-ams-publisher/ams-publisher.conf'
 logfile = '/var/log/argo-nagios-ams-publisher/ams-publisher.log'
@@ -47,7 +48,8 @@ def main():
     logger = lobj.get()
     confopts = config.parse_config(logger)
     nagioshost = confopts['general']['host']
-    timestamp = datetime.datetime.now().strftime('%Y-%m-%dT%H:%M:%SZ')
+    tz = pytz.timezone(confopts['general']['timezone'])
+    timestamp = datetime.datetime.now(tz).strftime('%Y-%m-%dT%H:%M:%SZ')
 
     parser.add_argument('--servicestatetype', required=True, type=str)
     parser.add_argument('--queue', required=True, type=str)


### PR DESCRIPTION
This one adds new config option:
```
[General]
Timezone = UTC
```
It forces timestamp of messages coming out from nagios to be converted into defined Timezone.