### PR TITLE
ARGO-806 AMS Publisher nagios testing method for upcoming probe

### DIFF
--- a/bin/ams-publisherd
+++ b/bin/ams-publisherd
@@ -35,6 +35,8 @@ logger = None
 
 
 def setup_statssocket(path):
+    if os.path.exists(path):
+        os.unlink(path)
     sock = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
     sock.bind(path)
 

--- a/pymod/consume.py
+++ b/pymod/consume.py
@@ -25,7 +25,6 @@ class ConsumerQueue(StatSig, Process):
         super(ConsumerQueue, self).__init__(worker=worker)
         self.name = worker
         self.events = events
-        # self.statint = statint
         self.sess_consumed = 0
 
         self.seenmsgs = set()

--- a/pymod/consume.py
+++ b/pymod/consume.py
@@ -25,7 +25,7 @@ class ConsumerQueue(StatSig, Process):
         super(ConsumerQueue, self).__init__(worker=worker)
         self.name = worker
         self.events = events
-
+        # self.statint = statint
         self.sess_consumed = 0
 
         self.seenmsgs = set()
@@ -101,9 +101,8 @@ class ConsumerQueue(StatSig, Process):
                 raise SystemExit(0)
 
     def _increm_intervalcounters(self, num):
-        for m in ['15', '30', '60', '180', '360', '720', '1440']:
-            codecon = "self.shared.stats['consumed%s'] += %d" % (m, num)
-            exec codecon
+        for i in range(len(self.shared.statint[self.name]['consumed'])):
+            self.shared.statint[self.name]['consumed'][i] += num
 
     def consume_dirq_msgs(self, num=0):
         def _inmemq_append(elem):

--- a/pymod/publish.py
+++ b/pymod/publish.py
@@ -21,6 +21,10 @@ class Publish(StatSig):
     def write(self, num=0):
         pass
 
+    def _increm_intervalcounters(self, num):
+        for i in range(len(self.shared.statint[self.name]['published'])):
+            self.shared.statint[self.name]['published'][i] += num
+
 class FilePublisher(Publish):
     """
        Publisher that write the messages into a file. Used only for debugging
@@ -30,7 +34,7 @@ class FilePublisher(Publish):
         self.shared = Shared(worker=worker)
         self.inmemq = self.shared.runtime['inmemq']
         self.pubnumloop = self.shared.runtime['pubnumloop']
-        self.worker = worker
+        self.name = worker
         super(FilePublisher, self).__init__(worker=worker)
 
     def write(self, num=0):
@@ -91,9 +95,7 @@ class MessagingPublisher(Publish):
                         self.ams.publish(self.shared.topic['topic'], msgs, timeout=self.shared.connection['timeout'])
                         published.update([self.inmemq[e][0] for e in range(self.shared.topic['bulk'])])
                         self.shared.stats['published'] += self.shared.topic['bulk']
-                        for m in ['15', '30', '60', '180', '360', '720', '1440']:
-                            codepub = "self.shared.stats['published%s'] += self.shared.topic['bulk']" % m
-                            exec codepub
+                        self._increm_intervalcounters(self.shared.topic['bulk'])
                         self.inmemq.rotate(-self.shared.topic['bulk'])
                         break
 

--- a/pymod/run.py
+++ b/pymod/run.py
@@ -13,10 +13,11 @@ def init_dirq_consume(workers, daemonized, sockstat):
     """
        Initialize local cache/directory queue consumers. For each Queue defined
        in configuration, one worker process will be spawned and Publisher will
-       be associated. Register also local SIGTERM and SIGUSR events that will
-       be triggered upon receiving same signals from daemon control process and
-       that will be used to control the behaviour of spawned subprocesses and
-       threads.
+       be associated. Additional one process will be spawned to listen for
+       queries on the socket. Register also local SIGTERM and SIGUSR events
+       that will be triggered upon receiving same signals from daemon control
+       process and that will be used to control the behaviour of spawned
+       subprocesses and threads.
     """
     evsleep = 2
     consumers = list()

--- a/pymod/shared.py
+++ b/pymod/shared.py
@@ -46,8 +46,8 @@ class Shared(object):
             self.log= None
         self.log = logger
 
-    def get_nmsg_interval(self, worker, key):
-        return self._stats[worker][key]
+    def get_nmsg_interval(self, worker, what, interval):
+        return self.statint[worker][what][interval]
 
     def event(self, name):
         return self.events.get(name)

--- a/pymod/shared.py
+++ b/pymod/shared.py
@@ -22,6 +22,7 @@ class Shared(object):
                 self.connection = confopts['connection']
             if not getattr(self, '_stats', False):
                 self._stats = dict()
+                self.statint = dict()
             self.workers = self._queues.keys()
         if worker:
             self.worker = worker
@@ -30,11 +31,8 @@ class Shared(object):
             if worker not in self._stats:
                 self._stats[worker] = dict(published=0)
                 self._stats[worker].update(dict(consumed=0))
-                for m in ['15', '30', '60', '180', '360', '720', '1440']:
-                    codepub = "self._stats[worker].update(dict(published%s=0))" % m
-                    codecon = "self._stats[worker].update(dict(consumed%s=0))" % m
-                    exec codepub
-                    exec codecon
+            if worker not in self.statint:
+                self.statint[worker] = dict(published=None, consumed=None)
             self.stats = self._stats[worker]
 
 

--- a/pymod/stats.py
+++ b/pymod/stats.py
@@ -147,7 +147,7 @@ class StatSock(Process):
                     q = self.parse_cmd(data)
                     if q:
                         a = self.answer(q)
-                        self.shared.log.error(a)
+                        conn.send(a, maxcmdlength)
                 if self.events['term-stats'].is_set():
                     self.shared.log.info('Stats received SIGTERM')
                     self.events['term-stats'].clear()

--- a/pymod/stats.py
+++ b/pymod/stats.py
@@ -102,8 +102,7 @@ class StatSock(Process):
                     q = self.parse_cmd(data)
                     if q:
                         a = self.answer(q)
-                        # self.shared.log.error('Answer %s %d' % (self.shared._stats, id(self.shared._stats['metrics'])))
-                        self.shared.log.error('Answer %s' % a)
+                        self.shared.log.error('Answer %s' % self.shared.statint['metrics']['consumed'][:])
                 if self.events['term-stats'].is_set():
                     self.shared.log.info('Stats received SIGTERM')
                     self.events['term-stats'].clear()

--- a/pymod/stats.py
+++ b/pymod/stats.py
@@ -90,7 +90,7 @@ class Reset(Thread):
 
 class StatSock(Process):
     """
-       Query'n'Answer process that listens and parses queries on local socket
+       Listen'n'Answer process that listens and parses queries on local socket
        and replies back with answer. Queries are in form of
 
          "w:<worker>+g:<published/consumed><interval>"

--- a/pymod/stats.py
+++ b/pymod/stats.py
@@ -77,8 +77,14 @@ class StatSock(Process):
                 w = w.split(':')[1]
                 g = g.split(':')[1]
                 r = re.search('([a-zA-Z]+)([0-9]+)', g)
-                if r:
-                    queries.append((w, r.group(1), self._int2idx[r.group(2)]))
+                try:
+                    if r:
+                        queries.append((w, r.group(1), self._int2idx[r.group(2)]))
+                    else:
+                        queries.append((w, 'error'))
+                except KeyError:
+                    queries.append((w, 'error'))
+
 
         if len(queries) > 0:
             return queries
@@ -88,8 +94,11 @@ class StatSock(Process):
     def answer(self, query):
         a = ''
         for q in query:
-            r = self.shared.get_nmsg_interval(q[0], q[1], q[2])
-            a += 'w:%s+r:%s ' % (str(q[0]), str(r))
+            if q[1] != 'error':
+                r = self.shared.get_nmsg_interval(q[0], q[1], q[2])
+                a += 'w:%s+r:%s ' % (str(q[0]), str(r))
+            else:
+                a += 'w:%s+r:error ' % str(q[0])
 
         return a[:-1]
 


### PR DESCRIPTION
This one introduces local socket and additional Listen'n'Answer process that listens and parses queries on local socket and replies back with answer. 

Queries are in form of `w:<worker>+g:<published/consumed><interval>` where for each worker process consumed or published number of messages can be asked for interval of last 15, 30, 60, 180, 360, 720 and 1440 minutes. Answer is served as `w:<worker>+r:<num of messages or error>`.

Communication and inspection through local socket will be used by Nagios sensor that will ask for trends/stats of published messages in desired time period. If number of published messages for any worker process (for example metrics, alarms) is below some threshold observed and usual for time period, sensor will complain with CRITICAL status.