### PR TITLE
ARGO-1023 Send messages to prod and devel AMS instance in parallel

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,11 +2,11 @@
 
 ## Description 
 
-`argo-nagios-ams-publisher` is a component acting as bridge from Nagios to ARGO Messaging system. It's integral part of software stack running on ARGO monitoring instance and is responsible for forming and dispatching messages that are results of Nagios tests. It is running as a unix daemon and it consists of two subsystems:
+`argo-nagios-ams-publisher` is a component acting as bridge from Nagios to ARGO Messaging system. It's integral part of software stack running on ARGO monitoring instance and is responsible for forming and dispatching messages that wrap up results of Nagios tests. It is running as a unix daemon and it consists of two subsystems:
 - queueing mechanism 
 - publishing/dispatching part
 
-Messages are cached in local queue with the help of OCSP Nagios calls and each queue is being monitored by the daemon. After configurable amount of accumulated messages, publisher that is associated to queue sends them to ARGO Messaging
+Messages are cached in local directory queue with the help of OCSP Nagios calls and each queue is being monitored by the daemon. After configurable amount of accumulated messages, publisher that is associated to queue sends them to ARGO Messaging
 system and drains the queue. `argo-nagios-ams-publisher` is written in multiprocessing manner so there is support for multiple queue/publish pairs where for each, new worker process will be spawned. 
 
 ### Features
@@ -19,3 +19,4 @@ Some of the main features are:
 - configurable watch rate for queue
 - configurable bulk of messages sent to ARGO Messaging system
 - purger that will keep queue only with sound data
+- message rate inspection of each worker for monitoring purposes 

--- a/pymod/alarmtoqueue.py
+++ b/pymod/alarmtoqueue.py
@@ -50,7 +50,7 @@ def main():
     tz = pytz.timezone(confopts['general']['timezone'])
     timestamp = datetime.datetime.now(tz).strftime('%Y-%m-%dT%H:%M:%SZ')
 
-    parser.add_argument('--queue', required=True, type=str)
+    parser.add_argument('--queue', required=True, nargs='+')
 
     # msg headers
     parser.add_argument('--service', required=True, type=str)
@@ -71,12 +71,13 @@ def main():
     seteuser(pwd.getpwnam(confopts['general']['runasuser']))
 
     try:
-        granularity = config.get_queue_granul(args.queue)
-        mq = DQS(path=args.queue, granularity=granularity)
+        for q in args.queue:
+            granularity = config.get_queue_granul(q)
+            mq = DQS(path=q, granularity=granularity)
 
-        msg = build_msg(args, timestamp, args.service, args.hostname, \
-                        args.testname, args.status, nagioshost)
-        mq.add_message(msg)
+            msg = build_msg(args, timestamp, args.service, args.hostname, \
+                            args.testname, args.status, nagioshost)
+            mq.add_message(msg)
 
     except MessageError as e:
         logger.error('Error constructing alarm - %s', repr(e))

--- a/pymod/metrictoqueue.py
+++ b/pymod/metrictoqueue.py
@@ -52,7 +52,7 @@ def main():
     timestamp = datetime.datetime.now(tz).strftime('%Y-%m-%dT%H:%M:%SZ')
 
     parser.add_argument('--servicestatetype', required=True, type=str)
-    parser.add_argument('--queue', required=True, type=str)
+    parser.add_argument('--queue', required=True, nargs='+')
 
     # msg headers
     parser.add_argument('--service', required=True, type=str)
@@ -73,20 +73,21 @@ def main():
 
     if 'HARD' in args.servicestatetype:
         try:
-            granularity = config.get_queue_granul(args.queue)
-            mq = DQS(path=args.queue, granularity=granularity)
+            for q in args.queue:
+                granularity = config.get_queue_granul(q)
+                mq = DQS(path=q, granularity=granularity)
 
-            if ',' in args.service:
-                services = args.service.split(',')
-                services = [s.strip() for s in services]
-                for service in services:
-                    msg = build_msg(args, timestamp, service, args.hostname, \
+                if ',' in args.service:
+                    services = args.service.split(',')
+                    services = [s.strip() for s in services]
+                    for service in services:
+                        msg = build_msg(args, timestamp, service, args.hostname, \
+                                        args.metric, args.status, nagioshost)
+                        mq.add_message(msg)
+                else:
+                    msg = build_msg(args, timestamp, args.service, args.hostname, \
                                     args.metric, args.status, nagioshost)
                     mq.add_message(msg)
-            else:
-                msg = build_msg(args, timestamp, args.service, args.hostname, \
-                                args.metric, args.status, nagioshost)
-                mq.add_message(msg)
 
         except MessageError as e:
             logger.error('Error constructing metric - %s', repr(e))


### PR DESCRIPTION
Added support for delivery of a single Nagios metric result to multiple local directory caches/queues. Alarms and metric delivery tools are extended so they can take multiple queues as arguments.